### PR TITLE
feat: optimize BLAKE3 hashing with parallel processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # ImagesSorter
 
-A high-performance Rust CLI application for organizing media files on macOS, optimized for Apple Silicon processors. Designed to process millions of files efficiently while detecting duplicates and organizing them by date.
+A high-performance Rust CLI application for organizing and managing media files on macOS, optimized for Apple Silicon processors. Designed to process millions of files efficiently while detecting duplicates and organizing them by date.
 
 ## Features
 
 - **High Performance**: Process 1,000+ files per second on Apple Silicon
 - **Memory Efficient**: Uses under 500MB RAM regardless of folder size
 - **Duplicate Detection**: BLAKE3-based fast hashing for finding duplicate files
-- **Smart Organization**: Organize files by date into a structured directory hierarchy
+- **Smart Organization**: Organize files by date into a structured directory hierarchy (YYYY/MM/DD)
+- **Deduplication**: Remove duplicate files with safety checks and detailed reporting
+- **Enhanced Progress Tracking**: Real-time progress bars with detailed statistics
 - **Supported Formats**:
   - **Images**: JPEG, PNG, HEIC/HEIF, RAW (CR2, NEF, ARW, DNG), GIF, BMP, TIFF, WebP
   - **Videos**: MP4, MOV, AVI, MKV, WebM, FLV, WMV
+- **Safety Features**: Dry-run mode, duplicate backup verification, detailed reports
 
 ## Prerequisites
 
@@ -46,33 +49,71 @@ cargo build --release
 ```
 
 The binary will be located at:
-- Debug: `target/debug/images-sorter`
-- Release: `target/release/images-sorter`
+- Debug: `target/debug/media-organizer`
+- Release: `target/release/media-organizer`
+
+3. (Optional) Install globally:
+```bash
+cargo install --path .
+```
 
 ## Usage
 
+### Organize Command
+
+Organize media files from a source directory into a date-based structure:
+
 ```bash
 # Basic usage
-images-sorter --input /path/to/source --output /path/to/destination
+media-organizer organize --input /path/to/source --output /path/to/destination
 
 # Short form
-images-sorter -i /source -o /dest
+media-organizer organize -i /source -o /dest
 
 # Dry run (preview without making changes)
-images-sorter -i /source -o /dest --dry-run
+media-organizer organize -i /source -o /dest --dry-run
 
 # Verbose output
-images-sorter -i /source -o /dest --verbose
+media-organizer organize -i /source -o /dest --verbose
 
 # Specify number of threads
-images-sorter -i /source -o /dest --threads 8
+media-organizer organize -i /source -o /dest --threads 8
+```
+
+### Deduplicate Command
+
+Find and remove duplicate files:
+
+```bash
+# Basic deduplication
+media-organizer deduplicate --directory /path/to/media
+
+# Short form
+media-organizer deduplicate -d /media
+
+# Dry run (preview what would be deleted)
+media-organizer deduplicate -d /media --dry-run
+
+# Generate a report of duplicates
+media-organizer deduplicate -d /media --report /path/to/report.txt
+
+# With verbose output
+media-organizer deduplicate -d /media --verbose
 ```
 
 ### Command Line Options
 
+#### Organize Command
 - `-i, --input <PATH>` - Source directory containing media files
 - `-o, --output <PATH>` - Destination directory for organized files
 - `-d, --dry-run` - Preview operations without making changes
+- `-v, --verbose` - Enable verbose logging
+- `-t, --threads <NUM>` - Number of threads for parallel processing (default: CPU count)
+
+#### Deduplicate Command
+- `-d, --directory <PATH>` - Directory to scan for duplicates
+- `--dry-run` - Preview what would be deleted without making changes
+- `-r, --report <PATH>` - Generate a detailed report of duplicates
 - `-v, --verbose` - Enable verbose logging
 - `-t, --threads <NUM>` - Number of threads for parallel processing (default: CPU count)
 
@@ -108,14 +149,34 @@ cargo clippy -- -D warnings
 cargo bench
 ```
 
+## Output Structure
+
+When organizing files, ImagesSorter creates a date-based directory structure:
+
+```
+output/
+├── 2024/
+│   ├── 01/
+│   │   ├── 15/
+│   │   │   ├── IMG_1234.jpg
+│   │   │   └── VID_5678.mp4
+│   │   └── 16/
+│   │       └── DSC_9012.raw
+│   └── 02/
+│       └── ...
+└── Unknown/
+    └── files_without_dates.jpg
+```
+
 ## Architecture
 
 The application uses:
 - **Tokio** for async runtime
 - **Rayon** for parallel processing
 - **BLAKE3** for fast, cryptographic hashing
-- **Indicatif** for progress bars
+- **Indicatif** for progress bars with real-time statistics
 - **Clap** for CLI parsing
+- **Chrono** for date/time handling
 
 ## Performance
 
@@ -124,6 +185,7 @@ Optimized for Apple Silicon with:
 - Parallel scanning and hashing
 - Efficient memory usage through iterators
 - Native Apple Silicon optimizations
+- Progress tracking with minimal overhead
 
 ## License
 

--- a/media-organizer/Cargo.toml
+++ b/media-organizer/Cargo.toml
@@ -29,8 +29,8 @@ walkdir = "2.4"
 # Date and time handling
 chrono = "0.4"
 
-# Fast hashing for duplicate detection
-blake3 = "1.5"
+# Fast hashing for duplicate detection with parallel support
+blake3 = { version = "1.5", features = ["rayon"] }
 
 # Progress bars
 indicatif = "0.17"

--- a/media-organizer/src/cli.rs
+++ b/media-organizer/src/cli.rs
@@ -97,6 +97,14 @@ pub struct OrganizeArgs {
     )]
     pub workers: usize,
 
+    /// Number of parallel workers for hash computation
+    #[arg(
+        long,
+        value_name = "NUM",
+        help = "Number of parallel workers for hash computation (defaults to workers value)"
+    )]
+    pub hash_workers: Option<usize>,
+
     /// Verbose output
     #[arg(short, long, help = "Enable verbose output")]
     pub verbose: bool,
@@ -196,6 +204,14 @@ pub struct DedupArgs {
         help = "Number of parallel workers (0 = auto-detect)"
     )]
     pub workers: usize,
+
+    /// Number of parallel workers for hash computation
+    #[arg(
+        long,
+        value_name = "NUM",
+        help = "Number of parallel workers for hash computation (defaults to workers value)"
+    )]
+    pub hash_workers: Option<usize>,
 
     /// Verbose output
     #[arg(short, long, help = "Enable verbose output")]

--- a/media-organizer/src/duplicate.rs
+++ b/media-organizer/src/duplicate.rs
@@ -5,8 +5,10 @@ use crate::types::FileInfo;
 use anyhow::Result;
 use blake3::Hasher;
 use indicatif::{ProgressBar, ProgressStyle};
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, BufReader};
 use tracing::{debug, info, warn};
@@ -26,6 +28,8 @@ pub struct DuplicateDetector {
     output_dir: PathBuf,
     /// Whether database needs saving
     database_modified: bool,
+    /// Number of parallel workers for hashing (None = use all CPU cores)
+    hash_workers: Option<usize>,
 }
 
 impl DuplicateDetector {
@@ -38,6 +42,23 @@ impl DuplicateDetector {
             database: HashDatabase::new(),
             output_dir: PathBuf::new(),
             database_modified: false,
+            hash_workers: None, // Use all CPU cores by default
+        }
+    }
+
+    /// Set the number of parallel workers for hashing
+    pub fn with_hash_workers(mut self, workers: usize) -> Self {
+        self.hash_workers = Some(workers);
+        self
+    }
+
+    /// Configure the rayon thread pool for hashing operations
+    fn configure_thread_pool(&self) {
+        if let Some(workers) = self.hash_workers {
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(workers)
+                .build_global()
+                .ok(); // Ignore error if already configured
         }
     }
 
@@ -55,6 +76,7 @@ impl DuplicateDetector {
             database,
             output_dir: output_dir.to_path_buf(),
             database_modified: false,
+            hash_workers: None,
         })
     }
     
@@ -77,6 +99,7 @@ impl DuplicateDetector {
             database,
             output_dir: output_dir.to_path_buf(),
             database_modified: false,
+            hash_workers: None,
         })
     }
 
@@ -204,28 +227,20 @@ impl DuplicateDetector {
             }
         }
         
-        // Second pass: hash the files that need it
-        for (idx, file_info) in files_to_hash.into_iter().enumerate() {
-            match self.compute_hash(&file_info.path).await {
-                Ok(hash) => {
-                    // Update database
-                    self.database.insert(
-                        file_info.path.clone(),
-                        hash.clone(),
-                        file_info.size,
-                        file_info.modified.timestamp(),
-                    );
-                    self.database_modified = true;
-                    
-                    self.existing_hashes.insert(hash, file_info.path);
-                    new_count += 1;
-                    
-                    if let Some(bar) = &hash_progress {
-                        bar.set_position((idx + 1) as u64);
+        // Second pass: hash the files that need it (in parallel)
+        if !files_to_hash.is_empty() {
+            let progress_arc = hash_progress.as_ref().map(|bar| Arc::new(bar.clone()));
+            let hash_results = self.compute_hashes_parallel(files_to_hash, progress_arc);
+            
+            for (file_info, hash_result) in hash_results {
+                match hash_result {
+                    Ok(hash) => {
+                        self.existing_hashes.insert(hash, file_info.path);
+                        new_count += 1;
                     }
-                }
-                Err(e) => {
-                    warn!("Failed to hash existing file {:?}: {}", file_info.path, e);
+                    Err(e) => {
+                        warn!("Failed to hash existing file {:?}: {}", file_info.path, e);
+                    }
                 }
             }
         }
@@ -255,7 +270,7 @@ impl DuplicateDetector {
         self.scan_output_directory_with_progress(output_dir, file_types, None).await
     }
 
-    /// Compute hash for a file
+    /// Compute hash for a file (async version for single files)
     pub async fn compute_hash(&mut self, path: &Path) -> Result<String> {
         // Check in-memory cache first
         if let Some(hash) = self.hash_cache.get(path) {
@@ -295,6 +310,101 @@ impl DuplicateDetector {
         self.hash_cache.insert(path.to_path_buf(), hash.clone());
 
         Ok(hash)
+    }
+
+    /// Compute hash for a file (sync version for parallel processing)
+    fn compute_hash_sync(path: &Path) -> Result<String> {
+        use std::fs::File;
+        use std::io::{BufReader, Read};
+        
+        debug!("Computing hash for {:?}", path);
+        
+        let file = File::open(path)?;
+        let mut reader = BufReader::new(file);
+        let mut hasher = Hasher::new();
+        
+        // Use larger buffer for better performance
+        let mut buffer = vec![0u8; 256 * 1024]; // 256KB buffer
+        
+        loop {
+            let bytes_read = reader.read(&mut buffer)?;
+            if bytes_read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..bytes_read]);
+        }
+        
+        Ok(hasher.finalize().to_hex().to_string())
+    }
+
+    /// Compute hashes for multiple files in parallel
+    pub fn compute_hashes_parallel(&mut self, files: Vec<FileInfo>, progress_bar: Option<Arc<ProgressBar>>) -> Vec<(FileInfo, Result<String>)> {
+        // Configure thread pool if needed
+        self.configure_thread_pool();
+        
+        // Filter out files already in cache
+        let (cached, to_compute): (Vec<_>, Vec<_>) = files.into_iter()
+            .partition(|file_info| {
+                // Check in-memory cache
+                if self.hash_cache.contains_key(&file_info.path) {
+                    return true;
+                }
+                
+                // Check database cache
+                if let Some(entry) = self.database.get(&file_info.path) {
+                    // Quick check without async metadata
+                    if file_info.size == entry.size {
+                        return true;
+                    }
+                }
+                
+                false
+            });
+        
+        // Get cached results
+        let mut results: Vec<(FileInfo, Result<String>)> = cached.into_iter()
+            .map(|file_info| {
+                let hash = self.hash_cache.get(&file_info.path)
+                    .cloned()
+                    .or_else(|| self.database.get(&file_info.path).map(|e| e.hash.clone()))
+                    .ok_or_else(|| anyhow::anyhow!("Cache miss"));
+                (file_info, hash)
+            })
+            .collect();
+        
+        // Compute remaining hashes in parallel
+        let computed: Vec<(FileInfo, Result<String>)> = to_compute
+            .into_par_iter()
+            .map(|file_info| {
+                let hash_result = Self::compute_hash_sync(&file_info.path);
+                
+                // Update progress bar if provided
+                if let Some(ref bar) = progress_bar {
+                    bar.inc(1);
+                }
+                
+                (file_info, hash_result)
+            })
+            .collect();
+        
+        // Update cache with computed hashes
+        for (file_info, hash_result) in &computed {
+            if let Ok(hash) = hash_result {
+                self.hash_cache.insert(file_info.path.clone(), hash.clone());
+                
+                // Update database
+                self.database.insert(
+                    file_info.path.clone(),
+                    hash.clone(),
+                    file_info.size,
+                    file_info.modified.timestamp(),
+                );
+                self.database_modified = true;
+            }
+        }
+        
+        results.extend(computed);
+        results
     }
 
     /// Check if a file is a duplicate and handle according to strategy

--- a/media-organizer/src/lib.rs
+++ b/media-organizer/src/lib.rs
@@ -86,7 +86,12 @@ pub async fn run_with_args(args: Args) -> Result<()> {
 
         // Initialize duplicate detector if enabled
         if args.detect_duplicates {
-            duplicate_detector = Some(DuplicateDetector::new(args.duplicate_strategy));
+            let hash_workers = args.hash_workers.or(Some(args.get_worker_count()));
+            let mut detector = DuplicateDetector::new(args.duplicate_strategy);
+            if let Some(workers) = hash_workers {
+                detector = detector.with_hash_workers(workers);
+            }
+            duplicate_detector = Some(detector);
             
             // Pre-scan output directory for existing files
             if let Some(detector) = duplicate_detector.as_mut() {

--- a/media-organizer/src/main.rs
+++ b/media-organizer/src/main.rs
@@ -137,7 +137,12 @@ async fn run_organize(args: cli::OrganizeArgs) -> Result<()> {
 
         // Initialize duplicate detector if enabled
         if args.detect_duplicates {
-            duplicate_detector = Some(DuplicateDetector::new(args.duplicate_strategy));
+            let hash_workers = args.hash_workers.or(Some(args.get_worker_count()));
+            let mut detector = DuplicateDetector::new(args.duplicate_strategy);
+            if let Some(workers) = hash_workers {
+                detector = detector.with_hash_workers(workers);
+            }
+            duplicate_detector = Some(detector);
             
             // Pre-scan output directory for existing files
             if let Some(detector) = duplicate_detector.as_mut() {


### PR DESCRIPTION
## Summary
- Enable BLAKE3's rayon feature for multi-threaded hashing capabilities
- Implement parallel file hashing to process multiple files concurrently
- Add configurable hash workers via CLI option

## Changes
- **Cargo.toml**: Enable `rayon` feature for blake3 dependency
- **duplicate.rs**: 
  - Add `compute_hash_sync()` for synchronous hashing in parallel contexts
  - Implement `compute_hashes_parallel()` to process multiple files concurrently
  - Increase buffer size from 64KB to 256KB for better I/O performance
  - Add configurable worker pool with `with_hash_workers()` method
- **cli.rs**: Add `--hash-workers` option to control parallelism
- **main.rs & lib.rs**: Wire up hash workers configuration

## Performance Impact
- Files are now hashed in parallel using all available CPU cores by default
- Configurable worker count allows tuning for different scenarios:
  - CPU-bound: Match CPU core count (default)
  - I/O-bound: Can use higher worker counts (e.g., 50-100)
- Larger buffer size reduces system calls and improves throughput

## Usage
```bash
# Use default (all CPU cores)
./media-organizer organize -i /source -o /dest

# Use 8 workers for hashing
./media-organizer organize -i /source -o /dest --hash-workers 8

# Use 100 workers (for I/O-bound scenarios)
./media-organizer organize -i /source -o /dest --hash-workers 100
```

## Test plan
- [x] Code compiles without errors
- [ ] Test with small dataset to verify correctness
- [ ] Benchmark performance improvements with large dataset
- [ ] Verify hash workers configuration works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)