### PR TITLE
fix: simplify init-db command to use single directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ cargo run -- organize -i /path/to/source -o /path/to/destination
 cargo run -- dedup -d /path/to/directory --dry-run
 
 # Initialize/update hash database
-cargo run -- init-db -d /path/to/source -o /path/to/output
+cargo run -- init-db -d /path/to/folder
 
 # Run with verbose logging
 RUST_LOG=debug cargo run -- organize -i /source -o /dest --verbose

--- a/PRD.md
+++ b/PRD.md
@@ -161,20 +161,18 @@ media-organizer dedup \
 #### Init-DB Command (New Feature)
 ```bash
 # Basic usage
-media-organizer init-db --directory /path/to/folder --output /path/to/output
+media-organizer init-db --directory /path/to/folder
 
 # With options
 media-organizer init-db \
   --directory /path/to/folder \
-  --output /path/to/output \
   --cleanup \
   --json \
   --verbose
 ```
 
 ##### Required Arguments
-- `--directory, -d`: Directory to scan for creating the hash database
-- `--output, -o`: Output directory where the database will be saved
+- `--directory, -d`: Directory to scan and where the hash database will be created
 
 ##### Optional Arguments
 - `--types, -t`: Comma-separated list of file types to process

--- a/media-organizer/README.md
+++ b/media-organizer/README.md
@@ -117,33 +117,33 @@ media-organizer dedup -d ~/Documents -e "*.tmp" -e "backup/*"
 
 ### Init-DB Command (New!)
 
-Pre-compute or update the hash database without organizing files. This significantly speeds up subsequent organization runs by caching file hashes.
+Pre-compute or update the hash database without organizing files. This significantly speeds up subsequent organization runs by caching file hashes. The database (db.mediaorg) is created in the scanned directory.
 
 #### Basic Usage
 ```bash
 # Initialize database for a directory
-media-organizer init-db -d /path/to/media -o /path/to/output
+media-organizer init-db -d /path/to/media
 
 # Update existing database (only hashes new/modified files)
-media-organizer init-db -d /path/to/media -o /path/to/output
+media-organizer init-db -d /path/to/media
 
 # Clean up obsolete entries and update database
-media-organizer init-db -d /path/to/media -o /path/to/output --cleanup
+media-organizer init-db -d /path/to/media --cleanup
 ```
 
 #### Advanced Options
 ```bash
 # Output statistics in JSON format
-media-organizer init-db -d ~/Photos -o ~/Organized --json
+media-organizer init-db -d ~/Photos --json
 
 # Process only specific file types
-media-organizer init-db -d ~/Media -o ~/Output -t jpg,png,mp4
+media-organizer init-db -d ~/Media -t jpg,png,mp4
 
 # Verbose output to see progress
-media-organizer init-db -d ~/Pictures -o ~/Backup -v
+media-organizer init-db -d ~/Pictures -v
 
 # Set custom number of workers
-media-organizer init-db -d ~/Large -o ~/Storage -j 16 --hash-workers 8
+media-organizer init-db -d ~/Large -j 16 --hash-workers 8
 ```
 
 ## Command Line Options
@@ -181,8 +181,7 @@ media-organizer init-db -d ~/Large -o ~/Storage -j 16 --hash-workers 8
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-d, --directory <DIR>` | Directory to scan | Required |
-| `-o, --output <DIR>` | Output directory for database | Required |
+| `-d, --directory <DIR>` | Directory to scan and store database | Required |
 | `-t, --types <TYPES>` | File types to process | all |
 | `-j, --workers <NUM>` | Parallel workers (0=auto) | 0 |
 | `--hash-workers <NUM>` | Hash computation workers | same as -j |

--- a/media-organizer/src/cli.rs
+++ b/media-organizer/src/cli.rs
@@ -266,13 +266,9 @@ pub struct DedupArgs {
 /// Arguments for the init-db command
 #[derive(Parser, Debug)]
 pub struct InitDbArgs {
-    /// Directory to scan for creating the hash database
+    /// Directory to scan and where the hash database will be created
     #[arg(short, long, value_name = "DIR")]
     pub directory: PathBuf,
-    
-    /// Output directory where the database will be saved
-    #[arg(short, long, value_name = "DIR")]
-    pub output: PathBuf,
 
     /// File types to process (default: all supported types)
     #[arg(
@@ -593,14 +589,6 @@ impl InitDbArgs {
             anyhow::bail!("Path is not a directory: {}", self.directory.display());
         }
 
-        // Check if output directory exists (we'll create the database file there)
-        if !self.output.exists() {
-            anyhow::bail!("Output directory does not exist: {}", self.output.display());
-        }
-
-        if !self.output.is_dir() {
-            anyhow::bail!("Output path is not a directory: {}", self.output.display());
-        }
 
         // Validate file size constraints
         if let Some(max_size) = self.max_size {

--- a/media-organizer/src/main.rs
+++ b/media-organizer/src/main.rs
@@ -75,7 +75,6 @@ async fn main() -> Result<()> {
 
             info!("Starting Database Initialization");
             info!("Directory: {}", args.directory.display());
-            info!("Output: {}", args.output.display());
             info!("Workers: {}", args.get_worker_count());
 
             match run_init_db(args).await {
@@ -367,7 +366,7 @@ async fn run_init_db(args: InitDbArgs) -> Result<()> {
     let mut progress = ProgressTracker::new(false);
 
     // Load existing database if present
-    let mut db = HashDatabase::load(&args.output).await?;
+    let mut db = HashDatabase::load(&args.directory).await?;
     
     if args.cleanup {
         info!("Cleaning up obsolete entries from database...");
@@ -486,8 +485,8 @@ async fn run_init_db(args: InitDbArgs) -> Result<()> {
         progress.finish_duplicate_detection();
 
         // Save the database
-        info!("Saving database to {:?}", args.output);
-        db.save(&args.output).await?;
+        info!("Saving database to {:?}", args.directory);
+        db.save(&args.directory).await?;
 
         // Report statistics
         let stats = db.stats();

--- a/test_init_db.sh
+++ b/test_init_db.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Test script for the updated init-db command
+
+echo "Testing init-db command with single directory parameter..."
+echo
+
+# Create a test directory structure
+TEST_DIR="/tmp/test_media_organizer"
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR/photos"
+mkdir -p "$TEST_DIR/videos"
+
+# Create some dummy files
+echo "Creating test files..."
+for i in {1..5}; do
+    touch "$TEST_DIR/photos/photo$i.jpg"
+    touch "$TEST_DIR/videos/video$i.mp4"
+done
+
+# Run init-db command
+echo "Running init-db command..."
+echo "Command: cargo run -- init-db -d $TEST_DIR"
+cargo run --manifest-path=media-organizer/Cargo.toml -- init-db -d "$TEST_DIR"
+
+# Check if database was created
+echo
+echo "Checking for database file..."
+if [ -f "$TEST_DIR/db.mediaorg" ]; then
+    echo "✅ Database file created successfully at: $TEST_DIR/db.mediaorg"
+    ls -la "$TEST_DIR/db.mediaorg"
+else
+    echo "❌ Database file not found!"
+fi
+
+echo
+echo "Test complete. Cleaning up..."
+rm -rf "$TEST_DIR"


### PR DESCRIPTION
## Summary
- Simplified the `init-db` command by removing the separate output directory parameter
- The database is now saved in the same directory being scanned
- Updated all related documentation to reflect this change

## Changes
- Removed `--output` parameter from `InitDbArgs` struct
- Updated `run_init_db` function to use the scan directory for database storage
- Updated PRD.md to reflect the new command syntax
- Updated README.md with the simplified usage
- Removed validation checks for the output directory

## Benefits
- More intuitive usage: `init-db -d /path/to/folder` instead of requiring two paths
- Follows the pattern of storing metadata alongside the data it describes
- Reduces command complexity and potential for user error

## Test plan
- [x] Build and run tests
- [x] Test the simplified init-db command with various directories
- [x] Verify database is created in the scanned directory
- [x] Ensure backward compatibility with existing databases

🤖 Generated with [Claude Code](https://claude.ai/code)